### PR TITLE
Use user's default timezone for displaying time in chat messages

### DIFF
--- a/chatmessageview/src/main/java/com/eberrydigital/chatview/models/Message.java
+++ b/chatmessageview/src/main/java/com/eberrydigital/chatview/models/Message.java
@@ -3,7 +3,6 @@ package com.eberrydigital.chatview.models;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 
 import com.eberrydigital.chatview.R;
 import com.eberrydigital.chatview.util.DateFormatter;
@@ -12,8 +11,6 @@ import com.eberrydigital.chatview.util.IMessageStatusIconFormatter;
 import com.eberrydigital.chatview.util.IMessageStatusTextFormatter;
 import com.eberrydigital.chatview.util.ITimeFormatter;
 import com.eberrydigital.chatview.util.TimeUtils;
-
-import java.util.Calendar;
 
 /**
  * Message object
@@ -121,7 +118,7 @@ public class Message {
      * Constructor
      */
     public Message() {
-        created = TimeUtils.INSTANCE.getUTCDateTimeAsString();
+        created = TimeUtils.INSTANCE.getCurrentDateTimeAsString();
         mSendTimeFormatter = new DefaultTimeFormatter();
         mDateFormatter = new DateFormatter();
         mSendTimeFormatter = new DefaultTimeFormatter();
@@ -194,7 +191,7 @@ public class Message {
 
     public String getCreatedAt() {
         if (created == null ) {
-            created = TimeUtils.INSTANCE.getUTCDateTimeAsString();
+            created = TimeUtils.INSTANCE.getCurrentDateTimeAsString();
         }
         return created;
     }

--- a/chatmessageview/src/main/kotlin/com/eberrydigital/chatview/util/TimeUtils.kt
+++ b/chatmessageview/src/main/kotlin/com/eberrydigital/chatview/util/TimeUtils.kt
@@ -4,7 +4,10 @@ package com.eberrydigital.chatview.util
 import android.annotation.SuppressLint
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 /**
  * time utility class
@@ -38,7 +41,7 @@ object TimeUtils {
     }
 
     @Throws(Exception::class)
-     fun getParsedDate(date: String , format: String ?= "MMM. dd, yyyy") : String? {
+    fun getParsedDate(date: String, format: String? = "MMM. dd, yyyy"): String? {
         val sdf = SimpleDateFormat(DATEFORMAT, Locale.getDefault())
         var s2: String? = null
         val d: Date
@@ -53,11 +56,11 @@ object TimeUtils {
         return s2
     }
 
-     fun  getUTCDateTimeAsString(): String
-    {
-        val sdf =  SimpleDateFormat(DATEFORMAT);
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        val utcTime = sdf.format( Date());
-        return utcTime;
+    @JvmOverloads
+    fun getCurrentDateTimeAsString(chosenTimezone: TimeZone = TimeZone.getDefault()): String {
+        val sdf = SimpleDateFormat(DATEFORMAT).apply {
+            timeZone = chosenTimezone
+        }
+        return sdf.format(Date())
     }
 }


### PR DESCRIPTION
Use user's timezone instead of UTC when displaying timestamp for messages.